### PR TITLE
修复gittalk标签错误

### DIFF
--- a/layout/_comment/gitalk.ejs
+++ b/layout/_comment/gitalk.ejs
@@ -6,7 +6,7 @@
 		repo: '<%= theme.gitalk.repo %>',
 		owner: '<%= theme.gitalk.owner %>',
 		admin: ['<%= theme.gitalk.admin %>'],
-		id: location.pathname,
+		id: '<%= post.title %>',
 		distractionFreeMode: false
 	})
 	gitalk.render('gitalk-container');


### PR DESCRIPTION
如果新建一篇中文标题的文章，由于中文会被变成一串很长的字符作为gittalk的label，而label会有长度限制，从而导致无法正常评论（五个月前修复的bug只是没有pull，具体是什么错误已经忘了），通过把id改成post.title解决了这个问题。