### PR TITLE
修复 Giscus 评论从主页跳转跳转不会生效的问题

### DIFF
--- a/layout/_comment/giscus.ejs
+++ b/layout/_comment/giscus.ejs
@@ -1,13 +1,29 @@
 <div id="giscus"></div>
-<script src="https://giscus.app/client.js"
-        data-repo="<%= theme.giscus.repo %>"
-        data-repo-id="<%= theme.giscus.repo_id %>"
-        data-category="<%= theme.giscus.category %>"
-        data-category-id="<%= theme.giscus.category_id %>"
-        data-mapping="<%= theme.giscus.mapping %>"
-        data-input-position="<%= theme.giscus.input_position %>"
-        data-theme="<%= theme.giscus.theme %>"
-        data-lang="<%= theme.giscus.lang %>"
-        crossorigin="anonymous"
-        async>
+<script>
+  function loadGiscus() {
+    const old = document.querySelector('#giscus script');
+    if (old) old.remove();
+
+    const script = document.createElement('script');
+    script.src = "https://giscus.app/client.js";
+    script.setAttribute("data-repo", "<%= theme.giscus.repo %>");
+    script.setAttribute("data-repo-id", "<%= theme.giscus.repo_id %>");
+    script.setAttribute("data-category", "<%= theme.giscus.category %>");
+    script.setAttribute("data-category-id", "<%= theme.giscus.category_id %>");
+    script.setAttribute("data-mapping", "<%= theme.giscus.mapping %>");
+    script.setAttribute("data-input-position", "<%= theme.giscus.input_position %>");
+    script.setAttribute("data-theme", "<%= theme.giscus.theme %>");
+    script.setAttribute("data-lang", "<%= theme.giscus.lang %>");
+    script.setAttribute("data-loading", "<%= theme.giscus.loading %>");
+    script.async = true;
+    script.crossOrigin = "anonymous";
+
+    document.getElementById("giscus").appendChild(script);
+  }
+
+  loadGiscus();
+
+  document.addEventListener('pjax:end', () => {
+    loadGiscus();
+  });
 </script>


### PR DESCRIPTION
原来的写法如果从主页跳转进入文章会导致评论无法使用，因为 scripts 块没有正常加载，必须刷新页面才能恢复
新写法改成了通过函数动态加载，修复了这个问题
已在本地进行测试